### PR TITLE
:sparkles: refactor: ApiControllerBase 

### DIFF
--- a/exposition/src/main/java/org/lafabrique_epita/exposition/api/ApiControllerBase.java
+++ b/exposition/src/main/java/org/lafabrique_epita/exposition/api/ApiControllerBase.java
@@ -1,0 +1,10 @@
+package org.lafabrique_epita.exposition.api;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class ApiControllerBase {
+    // Pas de méthodes requises ici, juste le mapping de base
+}

--- a/exposition/src/main/java/org/lafabrique_epita/exposition/api/authentication/UserController.java
+++ b/exposition/src/main/java/org/lafabrique_epita/exposition/api/authentication/UserController.java
@@ -17,6 +17,7 @@ import org.lafabrique_epita.application.dto.authentication.ResponseAuthenticatio
 import org.lafabrique_epita.application.service.user.UserServiceAdapter;
 import org.lafabrique_epita.domain.entities.UserEntity;
 import org.lafabrique_epita.domain.exceptions.UserException;
+import org.lafabrique_epita.exposition.api.ApiControllerBase;
 import org.lafabrique_epita.exposition.configuration.JwtService;
 import org.lafabrique_epita.exposition.exception.ErrorMessage;
 import org.springframework.http.HttpStatus;
@@ -32,7 +33,7 @@ import java.util.Map;
 
 @Tag(name = "User", description = "The user API")
 @RestController
-public class UserController {
+public class UserController extends ApiControllerBase {
 
     private final UserServiceAdapter userService;
     private final AuthenticationManager authenticationManager;

--- a/exposition/src/main/java/org/lafabrique_epita/exposition/api/media/MovieController.java
+++ b/exposition/src/main/java/org/lafabrique_epita/exposition/api/media/MovieController.java
@@ -16,6 +16,7 @@ import org.lafabrique_epita.application.service.media.playlist_movies.PlaylistMo
 import org.lafabrique_epita.domain.entities.UserEntity;
 import org.lafabrique_epita.domain.enums.StatusEnum;
 import org.lafabrique_epita.domain.exceptions.MovieException;
+import org.lafabrique_epita.exposition.api.ApiControllerBase;
 import org.lafabrique_epita.exposition.api.media.response_class.Favorite;
 import org.lafabrique_epita.exposition.api.media.response_class.ResponseStatusAndFavorite;
 import org.lafabrique_epita.exposition.api.media.response_class.Status;
@@ -29,8 +30,7 @@ import java.util.List;
 
 @Tag(name = "Movie", description = "The movie API")
 @RestController
-//@RequestMapping("/movies")
-public class MovieController {
+public class MovieController extends ApiControllerBase {
 
     private final PlaylistMovieServiceAdapter playlistMovieService;
 

--- a/exposition/src/main/java/org/lafabrique_epita/exposition/api/media/SerieController.java
+++ b/exposition/src/main/java/org/lafabrique_epita/exposition/api/media/SerieController.java
@@ -10,6 +10,7 @@ import org.lafabrique_epita.domain.entities.PlayListTvEntity;
 import org.lafabrique_epita.domain.entities.PlayListTvID;
 import org.lafabrique_epita.domain.entities.SerieEntity;
 import org.lafabrique_epita.domain.entities.UserEntity;
+import org.lafabrique_epita.exposition.api.ApiControllerBase;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Serie", description = "The Serie API")
 @RestController
-public class SerieController {
+public class SerieController extends ApiControllerBase {
 
     private final SerieServiceImpl serieService;
 

--- a/exposition/src/main/java/org/lafabrique_epita/exposition/configuration/RootRedirectionFilter.java
+++ b/exposition/src/main/java/org/lafabrique_epita/exposition/configuration/RootRedirectionFilter.java
@@ -1,0 +1,30 @@
+package org.lafabrique_epita.exposition.configuration;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class RootRedirectionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+        log.info("Request URI: {}", request.getRequestURI());
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/exposition/src/main/java/org/lafabrique_epita/exposition/configuration/SecurityConfiguration.java
+++ b/exposition/src/main/java/org/lafabrique_epita/exposition/configuration/SecurityConfiguration.java
@@ -35,22 +35,17 @@ public class SecurityConfiguration {
                 .csrf(AbstractHttpConfigurer::disable) // Réactiver en Production
                 .cors(cors -> cors.configurationSource(corsConfigurationSource())) // Réactiver en Production suivant les cas
                 .authorizeHttpRequests(requests -> requests
-                        .requestMatchers("/login").permitAll()
-                        .requestMatchers("/register").permitAll()
+                        .requestMatchers("/api/v1/login").permitAll()
+                        .requestMatchers("/api/v1/register").permitAll()
                         .requestMatchers(SWAGGGER_WHITELIST).permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .exceptionHandling(exception -> exception
-//                                .authenticationEntryPoint( (req, resp, excep) -> {
-//                                    resp.setStatus(HttpServletResponse.SC_NOT_FOUND);
-//                                    resp.setContentType("application/json");
-//                                    resp.getWriter().write("{\"errors\": \"Not Found\"}");
-//                                })
                         .authenticationEntryPoint((request, response, authException) -> {
                             response.setContentType("application/json;charset=UTF-8");
                             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                            Map<String, ?> errors = Map.of("status", HttpServletResponse.SC_UNAUTHORIZED, "errorMessage", authException.getMessage());
+                            Map<String, ?> errors = Map.of("status", HttpServletResponse.SC_UNAUTHORIZED, "errorMessage", "Non autorisé");
                             response.getWriter().write(new ObjectMapper().writeValueAsString(errors));
                         }).accessDeniedHandler((request, response, accessDeniedException) -> {
                             response.setContentType("application/json;charset=UTF-8");

--- a/exposition/src/main/resources/application.properties
+++ b/exposition/src/main/resources/application.properties
@@ -8,10 +8,10 @@ spring.jpa.properties.hibernate.dialect= org.hibernate.dialect.PostgreSQLDialect
 
 spring.jpa.hibernate.ddl-auto=update
 
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=${SHOW_SQL:false}
+spring.jpa.properties.hibernate.format_sql=${FORMAT_SHOW_SQL:false}
 
-server.servlet.context-path=/api/v1
+#server.servlet.context-path=/api/v1
 
 #Configuration du token JWT
 
@@ -24,15 +24,11 @@ springdoc.api-docs.path=/api-docs
 server.forward-headers-strategy=framework
 springdoc.swagger-ui.defaultModelsExpandDepth=-1
 springdoc.swagger-ui.tryItOutEnabled=true
-#springdoc.swagger-ui.operationsSorter=method
+
 springdoc.swagger-ui.tagsSorter=alpha
 springdoc.swagger-ui.filter=true
-openapi.dev-url=http://localhost:8080/api/v1
-openapi.prod-url=https://movie-reminder.olprog.formation.fr/api/v1
-
-#
-#spring.mvc.throw-exception-if-no-handler-found=true
-#spring.web.resources.add-mappings=false
+openapi.dev-url=http://localhost:8080
+openapi.prod-url=https://movie-reminder.olprog.formation.fr
 
 
 spring.threads.virtual.enabled=true


### PR DESCRIPTION
- ApiControllerBase dans les contrôleurs et ajuste le mappage d'URL
- Petit log des routes utiliser
- Retrait de `server.servlet.context-path=/api/v1` dans application.properties
- ajout de 2 variables d'environnments (par défaut false) qui permettent de mettre ou retirer les logs SQL : 
  - SHOW_SQL=true
  - FORMAT_SHOW_SQL=true
