### PR TITLE
:sparkles: feat: Amélioration de l'API des épisodes

### DIFF
--- a/application/src/main/java/org/lafabrique_epita/application/dto/media/serie_post/EpisodePostDtoMapper.java
+++ b/application/src/main/java/org/lafabrique_epita/application/dto/media/serie_post/EpisodePostDtoMapper.java
@@ -7,7 +7,7 @@ public class EpisodePostDtoMapper {
     private EpisodePostDtoMapper() {
     }
 
-    public static EpisodeEntity convertToEpisodeEntity(EpisodePostDto episodePostDto) {
+    public static EpisodeEntity convertToEntity(EpisodePostDto episodePostDto) {
         EpisodeEntity episode = new EpisodeEntity();
         episode.setAirDate(episodePostDto.airDate());
         episode.setEpisodeNumber(episodePostDto.episodeNumber());

--- a/application/src/main/java/org/lafabrique_epita/application/dto/media/serie_post/SeasonPostDto.java
+++ b/application/src/main/java/org/lafabrique_epita/application/dto/media/serie_post/SeasonPostDto.java
@@ -15,7 +15,7 @@ public record SeasonPostDto(
         @NotNull(message = "L'id TMDB ne doit pas être nul")
         @NotBlank(message = "L'id TMDB ne doit pas être vide")
         @Positive(message = "L'id TMDB doit être positif")
-        int idTmdb,
+        Long idTmdb,
 
         @JsonProperty("poster_path")
         String posterPath,

--- a/application/src/main/java/org/lafabrique_epita/application/service/media/playlist_series/PlaylistTvServiceAdapter.java
+++ b/application/src/main/java/org/lafabrique_epita/application/service/media/playlist_series/PlaylistTvServiceAdapter.java
@@ -6,12 +6,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.lafabrique_epita.application.dto.media.GenreDto;
 import org.lafabrique_epita.application.dto.media.serie_get.SerieGetResponseDto;
 import org.lafabrique_epita.application.dto.media.serie_get.SerieGetResponseDtoMapper;
-import org.lafabrique_epita.application.dto.media.serie_post.SeriePostDto;
-import org.lafabrique_epita.application.dto.media.serie_post.SeriePostDtoMapper;
-import org.lafabrique_epita.application.dto.media.serie_post.SeriePostDtoResponseMapper;
-import org.lafabrique_epita.application.dto.media.serie_post.SeriePostResponseDto;
+import org.lafabrique_epita.application.dto.media.serie_post.*;
 import org.lafabrique_epita.domain.entities.*;
 import org.lafabrique_epita.domain.enums.StatusEnum;
+import org.lafabrique_epita.domain.exceptions.EpisodeException;
 import org.lafabrique_epita.domain.exceptions.SerieException;
 import org.lafabrique_epita.domain.repositories.*;
 import org.springframework.http.HttpStatus;
@@ -71,6 +69,25 @@ public class PlaylistTvServiceAdapter implements PlaylistTvServicePort {
 
         createAndSavePlayListTvEntity(serie, user);
         return SeriePostDtoResponseMapper.convertToSerieDto(serie);
+    }
+
+    @Override
+    public EpisodePostDto save(EpisodeEntity episodeEntity, UserEntity user) throws EpisodeException {
+        PlayListTvEntity playListTvEntity = new PlayListTvEntity();
+        playListTvEntity.setEpisode(episodeEntity);
+        playListTvEntity.setUser(user);
+        playListTvEntity.setFavorite(false);
+        playListTvEntity.setStatus(StatusEnum.A_REGARDER);
+        playListTvEntity.setScore(0);
+
+        PlayListTvID playListTvID = new PlayListTvID();
+        playListTvID.setEpisodeId(episodeEntity.getId());
+        playListTvID.setUserId(user.getId());
+
+        playListTvEntity.setId(playListTvID);
+
+        PlayListTvEntity pl = this.playListTvRepository.save(playListTvEntity);
+        return EpisodePostDtoMapper.convertToDto(pl.getEpisode());
     }
 
     @SneakyThrows

--- a/application/src/main/java/org/lafabrique_epita/application/service/media/playlist_series/PlaylistTvServicePort.java
+++ b/application/src/main/java/org/lafabrique_epita/application/service/media/playlist_series/PlaylistTvServicePort.java
@@ -1,10 +1,13 @@
 package org.lafabrique_epita.application.service.media.playlist_series;
 
 import org.lafabrique_epita.application.dto.media.serie_get.SerieGetResponseDto;
+import org.lafabrique_epita.application.dto.media.serie_post.EpisodePostDto;
 import org.lafabrique_epita.application.dto.media.serie_post.SeriePostDto;
 import org.lafabrique_epita.application.dto.media.serie_post.SeriePostResponseDto;
+import org.lafabrique_epita.domain.entities.EpisodeEntity;
 import org.lafabrique_epita.domain.entities.UserEntity;
 import org.lafabrique_epita.domain.enums.StatusEnum;
+import org.lafabrique_epita.domain.exceptions.EpisodeException;
 import org.lafabrique_epita.domain.exceptions.SerieException;
 
 import java.util.List;
@@ -12,6 +15,9 @@ import java.util.List;
 public interface PlaylistTvServicePort {
 
     SeriePostResponseDto save(SeriePostDto seriePostDto, UserEntity user) throws SerieException;
+
+    EpisodePostDto save(EpisodeEntity episodeEntity, UserEntity user) throws EpisodeException;
+
     List<SerieGetResponseDto> findAllEpisodesByUser(UserEntity user);
 
     boolean updateFavorite(Long episodeId, Integer favorite, Long userId) throws SerieException;

--- a/application/src/main/java/org/lafabrique_epita/application/service/media/serie/EpisodeServiceAdapter.java
+++ b/application/src/main/java/org/lafabrique_epita/application/service/media/serie/EpisodeServiceAdapter.java
@@ -1,0 +1,47 @@
+package org.lafabrique_epita.application.service.media.serie;
+
+import org.lafabrique_epita.application.dto.media.serie_post.EpisodePostDto;
+import org.lafabrique_epita.application.dto.media.serie_post.EpisodePostDtoMapper;
+import org.lafabrique_epita.domain.entities.EpisodeEntity;
+import org.lafabrique_epita.domain.entities.SeasonEntity;
+import org.lafabrique_epita.domain.exceptions.SerieException;
+import org.lafabrique_epita.domain.repositories.EpisodeRepository;
+import org.lafabrique_epita.domain.repositories.SeasonRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class EpisodeServiceAdapter implements EpisodeServicePort {
+
+
+    private final EpisodeRepository episodeRepository;
+    private final SeasonRepository seasonRepository;
+
+    public EpisodeServiceAdapter(EpisodeRepository episodeRepository, SeasonRepository seasonRepository) {
+        this.episodeRepository = episodeRepository;
+        this.seasonRepository = seasonRepository;
+    }
+
+    @Override
+    public EpisodeEntity save(EpisodePostDto episodePostDto, Long idTmdbSeason) throws SerieException {
+        // on récupère une DTO et on la convertit en entité
+        EpisodeEntity episode = EpisodePostDtoMapper.convertToEntity(episodePostDto);
+
+        // On doit vérifier si l'épisode existe déjà dans la base de données
+        Optional<EpisodeEntity> episodeEntity = this.episodeRepository.findByIdTmdb(episode.getIdTmdb());
+
+        // Si oui, on retourne l'épisode
+        if (episodeEntity.isPresent()) {
+           return episodeEntity.get();
+        }
+
+        // Sinon, on crée un nouvel épisode et on le retourne
+        Optional<SeasonEntity> seasonEntity = this.seasonRepository.findByIdTmdb(idTmdbSeason);
+        if (seasonEntity.isEmpty()) {
+            throw new SerieException("Saison introuvable");
+        }
+        episode.setSeason(seasonEntity.get());
+        return this.episodeRepository.save(episode);
+    }
+}

--- a/application/src/main/java/org/lafabrique_epita/application/service/media/serie/EpisodeServicePort.java
+++ b/application/src/main/java/org/lafabrique_epita/application/service/media/serie/EpisodeServicePort.java
@@ -1,0 +1,10 @@
+package org.lafabrique_epita.application.service.media.serie;
+
+import org.lafabrique_epita.application.dto.media.serie_post.EpisodePostDto;
+import org.lafabrique_epita.domain.entities.EpisodeEntity;
+import org.lafabrique_epita.domain.entities.SeasonEntity;
+import org.lafabrique_epita.domain.exceptions.SerieException;
+
+public interface EpisodeServicePort {
+    EpisodeEntity save(EpisodePostDto episodePostDto, Long idTmdbSeason) throws SerieException;
+}

--- a/domain/src/main/java/org/lafabrique_epita/domain/entities/SeasonEntity.java
+++ b/domain/src/main/java/org/lafabrique_epita/domain/entities/SeasonEntity.java
@@ -25,11 +25,11 @@ public class SeasonEntity extends MasterClass {
     private String overview;
 
     @Column(nullable = false, unique = true)
-    private int idTmdb;
+    private Long idTmdb;
 
     private String posterPath;
 
-    private int seasonNumber;
+    private Integer seasonNumber;
 
 
     @ManyToOne(optional = false)

--- a/domain/src/main/java/org/lafabrique_epita/domain/exceptions/EpisodeException.java
+++ b/domain/src/main/java/org/lafabrique_epita/domain/exceptions/EpisodeException.java
@@ -1,0 +1,14 @@
+package org.lafabrique_epita.domain.exceptions;
+
+import org.springframework.http.HttpStatus;
+
+public class EpisodeException extends MovieReminderException{
+
+    public EpisodeException(String message) {
+        super(message, HttpStatus.BAD_REQUEST);
+    }
+
+    public EpisodeException(String message, HttpStatus httpStatus) {
+        super(message, httpStatus);
+    }
+}

--- a/domain/src/main/java/org/lafabrique_epita/domain/repositories/EpisodeRepository.java
+++ b/domain/src/main/java/org/lafabrique_epita/domain/repositories/EpisodeRepository.java
@@ -3,9 +3,12 @@ package org.lafabrique_epita.domain.repositories;
 import org.lafabrique_epita.domain.entities.EpisodeEntity;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface EpisodeRepository {
     EpisodeEntity save(EpisodeEntity episodeEntity);
 
     List<EpisodeEntity> saveAll(List<EpisodeEntity> episodeEntity);
+
+    Optional<EpisodeEntity> findByIdTmdb(Long idTmdb);
 }

--- a/domain/src/main/java/org/lafabrique_epita/domain/repositories/SeasonRepository.java
+++ b/domain/src/main/java/org/lafabrique_epita/domain/repositories/SeasonRepository.java
@@ -4,10 +4,13 @@ import org.lafabrique_epita.domain.entities.SeasonEntity;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 public interface SeasonRepository {
     SeasonEntity save(SeasonEntity seasonEntity);
 
 
     List<SeasonEntity> saveAll(Collection<SeasonEntity> seasonEntity);
+
+    Optional<SeasonEntity> findByIdTmdb(Long idTmdbSeason);
 }

--- a/exposition/src/main/java/org/lafabrique_epita/exposition/api/media/EpisodeController.java
+++ b/exposition/src/main/java/org/lafabrique_epita/exposition/api/media/EpisodeController.java
@@ -8,9 +8,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.lafabrique_epita.application.dto.media.serie_post.EpisodePostDto;
 import org.lafabrique_epita.application.service.media.playlist_series.PlaylistTvServiceAdapter;
+import org.lafabrique_epita.application.service.media.serie.EpisodeServiceAdapter;
+import org.lafabrique_epita.domain.entities.EpisodeEntity;
 import org.lafabrique_epita.domain.entities.UserEntity;
 import org.lafabrique_epita.domain.enums.StatusEnum;
+import org.lafabrique_epita.domain.exceptions.EpisodeException;
 import org.lafabrique_epita.domain.exceptions.SerieException;
 import org.lafabrique_epita.exposition.api.ApiControllerBase;
 import org.lafabrique_epita.exposition.api.media.response_class.Favorite;
@@ -20,30 +25,36 @@ import org.lafabrique_epita.exposition.exception.ErrorMessage;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Episode", description = "L'API des épisodes")
 @RestController
 public class EpisodeController extends ApiControllerBase {
 
     private final PlaylistTvServiceAdapter playlistTvService;
+    private final EpisodeServiceAdapter episodeService;
 
-
-    public EpisodeController(PlaylistTvServiceAdapter playlistTvService) {
+    public EpisodeController(PlaylistTvServiceAdapter playlistTvService, EpisodeServiceAdapter episodeService) {
         this.playlistTvService = playlistTvService;
+        this.episodeService = episodeService;
     }
 
     @Operation(summary = "Ajouter un épisode à la liste des favoris ou modifier le statut",
             parameters = {
-                    @Parameter(name = "id", description = "Id de l'épisode", example = "1", schema = @Schema(implementation = Long.class)),
+                    @Parameter(name = "idTmdbSeason", description = "Id TMDB de la saison", example = "1154", schema = @Schema(implementation = Long.class)),
                     @Parameter(name = "favorite", description = "Ajouter ou supprimer un épisode de la liste des favoris (0=>retrait, 1=>ajout)", example = "1", schema = @Schema(implementation =
                             Integer.class)),
                     @Parameter(name = "status", description = "Modifier le statut du épisode (0=>A_REGARDER, 1=>EN_COURS, 2=>VU, 3=>ABANDON)", example = "0", schema = @Schema(implementation =
                             Integer.class))
-            })
+            },
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "Objet EpisodePostDto",
+                    required = true,
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = EpisodePostDto.class),
+                            examples = @ExampleObject(value = "{\"id_tmdb\":11,\"title\":\"The Lost Colony\",\"overview\":\"The crew discovers a colony thought to be lost for centuries and uncovers a plot that could threaten the universe.\",\"season_number\":2,\"episode_number\":1,\"air_date\":\"2012-05-20\",\"image_path\":\"/galactic_s2_e1.jpg\",\"duration\":50}", name = "Exemple d'objet EpisodePostDto"))
+            )
+    )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Episode ajouté à la liste des favoris ou statut modifié",
                     content = @Content(mediaType = "application/json",
@@ -67,13 +78,14 @@ public class EpisodeController extends ApiControllerBase {
                     schema = @Schema(implementation = ErrorMessage.class)
             ))
     })
-    @PatchMapping("/episodes/{id}")
-    public ResponseEntity<ResponseStatusAndFavorite> getFrontSerie(
-            @PathVariable Long id,
+    @PostMapping("/episodes/{idTmdbSeason}")
+    public ResponseEntity<ResponseStatusAndFavorite> saveEpisode(
+            @Valid @RequestBody EpisodePostDto episodePostDto,
+            @PathVariable Long idTmdbSeason,
             @RequestParam(required = false) Integer favorite,
             @RequestParam(required = false) Integer status,
             Authentication authentication
-    ) throws SerieException {
+    ) throws SerieException, EpisodeException {
         UserEntity userEntity = (UserEntity) authentication.getPrincipal();
 
         if (favorite == null && status == null) {
@@ -83,30 +95,34 @@ public class EpisodeController extends ApiControllerBase {
         if (favorite != null && status != null) {
             throw new SerieException("Le favori et le statut ne peuvent pas être fournis en même temps", HttpStatus.BAD_REQUEST);
         }
+        // Ici, on doit récupérer un id d'épisode, pas de saison
+        // Mais avant, il sauvegarde l'épisode dans la base de données
+        EpisodeEntity episode = this.episodeService.save(episodePostDto, idTmdbSeason);
+        this.playlistTvService.save(episode, userEntity);
 
         if (favorite != null) {
-            return updateFavorite(id, favorite, userEntity);
+            return updateFavorite(episode.getId(), favorite, userEntity);
         } else {
-            return updateStatus(id, status, userEntity);
+            return updateStatus(episode.getId(), status, userEntity);
         }
     }
 
-    private ResponseEntity<ResponseStatusAndFavorite> updateFavorite(Long id, Integer favorite, UserEntity userEntity) throws SerieException {
+    private ResponseEntity<ResponseStatusAndFavorite> updateFavorite(Long episodeId, Integer favorite, UserEntity userEntity) throws SerieException {
         if (favorite < 0 || favorite > 1) {
             throw new SerieException("Le favori doit être 0 ou 1 (0 => supprimer, 1 => ajouter)", HttpStatus.BAD_REQUEST);
         }
-        boolean fav = playlistTvService.updateFavorite(id, favorite, userEntity.getId());
+        boolean fav = playlistTvService.updateFavorite(episodeId, favorite, userEntity.getId());
         Favorite favoriteResponse = new Favorite(fav);
 
         return ResponseEntity.ok(favoriteResponse);
     }
 
-    private ResponseEntity<ResponseStatusAndFavorite> updateStatus(Long id, Integer status, UserEntity userEntity) throws SerieException {
+    private ResponseEntity<ResponseStatusAndFavorite> updateStatus(Long episodeId, Integer status, UserEntity userEntity) throws SerieException {
         if (status < 0 || status > 3) {
             throw new SerieException("Le statut doit être 0, 1, 2 ou 3 (0 => A_REGARDER, 1 => EN_COURS, 2 => VU, 3 => ABANDON)", HttpStatus.BAD_REQUEST);
         }
         StatusEnum statusEnum = statusToString(status);
-        playlistTvService.updateStatus(id, statusEnum, userEntity.getId());
+        playlistTvService.updateStatus(episodeId, statusEnum, userEntity.getId());
         Status s = new Status(statusEnum);
         return ResponseEntity.ok(s);
     }

--- a/infrastructure/src/main/java/org/lafabrique_epita/infrastructure/episode/EpisodeJPARepositoryPort.java
+++ b/infrastructure/src/main/java/org/lafabrique_epita/infrastructure/episode/EpisodeJPARepositoryPort.java
@@ -3,5 +3,8 @@ package org.lafabrique_epita.infrastructure.episode;
 import org.lafabrique_epita.domain.entities.EpisodeEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface EpisodeJPARepositoryPort extends JpaRepository<EpisodeEntity, Long> {
+    Optional<EpisodeEntity> findByIdTmdb(Long idTmdb);
 }

--- a/infrastructure/src/main/java/org/lafabrique_epita/infrastructure/episode/EpisodeRepositoryAdapter.java
+++ b/infrastructure/src/main/java/org/lafabrique_epita/infrastructure/episode/EpisodeRepositoryAdapter.java
@@ -5,6 +5,7 @@ import org.lafabrique_epita.domain.repositories.EpisodeRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public class EpisodeRepositoryAdapter implements EpisodeRepository {
@@ -23,5 +24,10 @@ public class EpisodeRepositoryAdapter implements EpisodeRepository {
     @Override
     public List<EpisodeEntity> saveAll(List<EpisodeEntity> episodeEntity) {
         return this.episodeJPARepository.saveAll(episodeEntity);
+    }
+
+    @Override
+    public Optional<EpisodeEntity> findByIdTmdb(Long idTmdb) {
+        return this.episodeJPARepository.findByIdTmdb(idTmdb);
     }
 }

--- a/infrastructure/src/main/java/org/lafabrique_epita/infrastructure/season/SeasonJPARepositoryPort.java
+++ b/infrastructure/src/main/java/org/lafabrique_epita/infrastructure/season/SeasonJPARepositoryPort.java
@@ -3,5 +3,8 @@ package org.lafabrique_epita.infrastructure.season;
 import org.lafabrique_epita.domain.entities.SeasonEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SeasonJPARepositoryPort extends JpaRepository<SeasonEntity, Long> {
+    Optional<SeasonEntity> findByIdTmdb(Long idTmdbSeason);
 }

--- a/infrastructure/src/main/java/org/lafabrique_epita/infrastructure/season/SeasonRepositoryAdapter.java
+++ b/infrastructure/src/main/java/org/lafabrique_epita/infrastructure/season/SeasonRepositoryAdapter.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public class SeasonRepositoryAdapter implements SeasonRepository {
@@ -23,5 +24,10 @@ public class SeasonRepositoryAdapter implements SeasonRepository {
     @Override
     public List<SeasonEntity> saveAll(Collection<SeasonEntity> seasonEntity) {
         return this.seasonJPARepositoryPort.saveAll(seasonEntity);
+    }
+
+    @Override
+    public Optional<SeasonEntity> findByIdTmdb(Long idTmdbSeason) {
+        return this.seasonJPARepositoryPort.findByIdTmdb(idTmdbSeason);
     }
 }


### PR DESCRIPTION
Ajoutez une nouvelle fonctionnalité pour sauvegarder un épisode dans la base de données avant de l'ajouter à la liste de lecture. Modifiez également le type des ID TMDB dans SeasonEntity de int à Long et le numéro de la saison de int à Integer. Ajoutez une nouvelle exception EpisodeException.